### PR TITLE
Consider versioned rocker as alternative to packrat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,8 @@ Suggests:
     ggfortify,
     bookdown,
     Hmisc,
-    testthat
+    testthat,
+    fitdistrplus
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ Suggests:
     purrr,
     tidyr,
     ggrepel,
+    ggfortify,
     bookdown,
     Hmisc,
     testthat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,18 @@
 # get the base image, this one has R, RStudio and pandoc
-FROM rocker/rstudio:3.3.2
+FROM rocker/tidyverse:3.3.2
 
 # required
 MAINTAINER Ben Marwick <benmarwick@gmail.com>
 
-# stay current
-RUN apt-get update -y \
-
-  # solve a mysterious & sudden error with XML pkg
-  && apt-get install libxml2-dev libssl-dev libcurl4-openssl-dev -y \
-  # get the full set of repository files from GitHub
-  && git clone https://github.com/benmarwick/mjbtramp.git \
-  # make these files writable
-  && chmod 777 -R mjbtramp \
+RUN git clone https://github.com/benmarwick/mjbtramp.git \
   # go into the repo directory
   && cd /mjbtramp \
   # start R and build pkgs that we depend on from local sources that we have collected with packrat
-  && R -e "0" --args --bootstrap-packrat \
+##  && R -e "0" --args --bootstrap-packrat \
+## Source the MRAN snapshot, so we install the same version of packages always
+  && . /etc/environment \
   # build this compendium package
-  && R -e 'devtools::install(".")' \
+  && R -e "devtools::install('.', dep=TRUE, repo='$MRAN')" \
   # render the manuscript into a docx
   && R -e "rmarkdown::render('analysis/paper/Marwick_Hayes_et_al.Rmd')"
 


### PR DESCRIPTION
I haven't used packrat recently, (always found it too much of a nuisance, though admittedly that was early days), but I think it can be troublesome.  

My thinking with the versioned docker images is that you shouldn't need to use packrat to make sure the Dockerfile thing always works.  As long as you are already using a DESCRIPTION file, that should be sufficient to get the dependencies.  

This PR is just a quick illustration of this which seems to work. Note I had to add two packages to Suggests that are called in the manuscript.  This means the circle build will fail until you merge the PR, since the `git clone` command still pulls in the R package with the old DESCRIPTION.  

I've built this on `tidyverse` instead of `rstudio`, since it has the libxml2 libraries there and many other packages you already install.  (Actually, you could use `rocker/verse:3.3.2` instead which would have more packages you are using installed (e.g. knitr, bookdown), so build even faster).

Note the key to this approach is these lines:

```
  ## load the saved MRAN env variable 
  && . /etc/environment \
  ## build this compendium package
  && R -e "devtools::install('.', dep=TRUE, repo='$MRAN')" \
```

which installs the package with suggests list from the version-locked snapshot (matching that of the upstream builds).  

Thanks for sharing this, nice to have a test example to play with that isn't from my own work.  Like packrat, the idea is that the recipe should work relatively well without Docker as well since it's just installing with the MRAN snapshot (though a user would have to set a custom `.libLoc` to avoid using possibly-more-recent versions of those packages).  And unlike packrat, the MRAN strategy doesn't help if you're using packages installed from GitHub.

Anyway, let me know what you think; and sorry for the kinks while I migrated some stuff out of `rocker/rstudio` and further downstream (like libxml).  

